### PR TITLE
feat: singularlize Payment type; export Payment and Upload

### DIFF
--- a/lib/arta.ts
+++ b/lib/arta.ts
@@ -1,16 +1,16 @@
 import { ArtaClient } from './ArtaClient';
+import { initLogger, Logger, LoggerVerbosity } from './logging';
 import { NodeHttpClient } from './net/NodeHttpClient';
 import { RestClient } from './net/RestClient';
-import { OrganizationsEndpoint } from './endpoint/organization';
-import { PaymentsEndpoint } from './endpoint/payments';
-import { WebhooksEndpoint } from './endpoint/webhooks';
-import { initLogger, Logger, LoggerVerbosity } from './logging';
-import { KeysEndpoint } from './endpoint/keys';
 import { AttachmentsEndpoint } from './endpoint/attachment';
-import { WebhookDeliveriesEndpoint } from './endpoint/webhookDeliveries';
-import { UploadsEndpoint } from './endpoint/uploads';
 import { EmailRulesEndpoint } from './endpoint/emailRules';
 import { EmailSubscriptionsEndpoint } from './endpoint/emailSubscriptions';
+import { KeysEndpoint } from './endpoint/keys';
+import { OrganizationsEndpoint } from './endpoint/organization';
+import { PaymentsEndpoint } from './endpoint/payments';
+import { UploadsEndpoint } from './endpoint/uploads';
+import { WebhookDeliveriesEndpoint } from './endpoint/webhookDeliveries';
+import { WebhooksEndpoint } from './endpoint/webhooks';
 
 export interface ArtaConfig {
   host: string;
@@ -28,15 +28,15 @@ export class Arta {
   private readonly artaClient: RestClient;
   private readonly config: ArtaConfig;
 
-  public organizations: OrganizationsEndpoint;
-  public payments: PaymentsEndpoint;
-  public webhooks: WebhooksEndpoint;
-  public keys: KeysEndpoint;
   public attachments: AttachmentsEndpoint;
-  public webhook_deliveries: WebhookDeliveriesEndpoint;
-  public uploads: UploadsEndpoint;
   public email_rules: EmailRulesEndpoint;
   public email_subscriptions: EmailSubscriptionsEndpoint;
+  public keys: KeysEndpoint;
+  public organizations: OrganizationsEndpoint;
+  public payments: PaymentsEndpoint;
+  public uploads: UploadsEndpoint;
+  public webhook_deliveries: WebhookDeliveriesEndpoint;
+  public webhooks: WebhooksEndpoint;
 
   constructor(apiKey: string, config?: Partial<ArtaConfig>) {
     this.config = Object.assign(defaultConfig, config);
@@ -48,14 +48,14 @@ export class Arta {
       host: this.config.host,
     });
 
-    this.organizations = new OrganizationsEndpoint(this.artaClient);
-    this.payments = new PaymentsEndpoint(this.artaClient);
-    this.webhooks = new WebhooksEndpoint(this.artaClient);
-    this.keys = new KeysEndpoint(this.artaClient);
     this.attachments = new AttachmentsEndpoint(this.artaClient);
-    this.webhook_deliveries = new WebhookDeliveriesEndpoint(this.artaClient);
-    this.uploads = new UploadsEndpoint(this.artaClient);
     this.email_rules = new EmailRulesEndpoint(this.artaClient);
     this.email_subscriptions = new EmailSubscriptionsEndpoint(this.artaClient);
+    this.keys = new KeysEndpoint(this.artaClient);
+    this.organizations = new OrganizationsEndpoint(this.artaClient);
+    this.payments = new PaymentsEndpoint(this.artaClient);
+    this.uploads = new UploadsEndpoint(this.artaClient);
+    this.webhook_deliveries = new WebhookDeliveriesEndpoint(this.artaClient);
+    this.webhooks = new WebhooksEndpoint(this.artaClient);
   }
 }

--- a/lib/endpoint/payments.ts
+++ b/lib/endpoint/payments.ts
@@ -6,7 +6,7 @@ import { DefaultEndpoint, Endpoint } from './endpoint';
 
 export type PaymentContext = 'hosted_checkout' | 'invoiced';
 
-export interface Payments extends DatedInterface {
+export interface Payment extends DatedInterface {
   id: ArtaID;
   amount: number;
   amount_currency: string;
@@ -15,25 +15,25 @@ export interface Payments extends DatedInterface {
 }
 
 export class PaymentsEndpoint {
-  private readonly defaultEndpoint: Endpoint<Payments, never>;
+  private readonly defaultEndpoint: Endpoint<Payment, never>;
   private readonly path = '/payments';
   constructor(private readonly artaClient: RestClient) {
-    this.defaultEndpoint = new DefaultEndpoint<Payments, never>(
+    this.defaultEndpoint = new DefaultEndpoint<Payment, never>(
       this.path,
       this.artaClient,
       this.enrichFields
     );
   }
 
-  public getById(id: ArtaID, auth?: string): Promise<Payments> {
+  public getById(id: ArtaID, auth?: string): Promise<Payment> {
     return this.defaultEndpoint.getById(id, auth);
   }
 
-  public list(page = 1, pageSize = 20, auth?: string): Promise<Page<Payments>> {
+  public list(page = 1, pageSize = 20, auth?: string): Promise<Page<Payment>> {
     return this.defaultEndpoint.list(page, pageSize, auth);
   }
 
-  private enrichFields(resource: Payments): Payments {
+  private enrichFields(resource: Payment): Payment {
     resource.amount = Number(resource.amount);
     resource.paid_on = new Date(resource.paid_on);
     return resource;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,9 +1,11 @@
 export { Arta } from './arta';
-export { Key } from './endpoint/keys';
+export { Logger, LoggerVerbosity } from './logging';
 export { Attachment } from './endpoint/attachment';
 export { EmailRule } from './endpoint/emailRules';
 export { EmailSubscription } from './endpoint/emailSubscriptions';
+export { Key } from './endpoint/keys';
 export { Organization } from './endpoint/organization';
+export { Payment } from './endpoint/payments';
+export { Upload } from './endpoint/uploads';
 export { Webhook } from './endpoint/webhooks';
 export { WebhookDeliveries } from './endpoint/webhookDeliveries';
-export { Logger, LoggerVerbosity } from './logging';


### PR DESCRIPTION
Sorry for moving the endpoints into a more or less alphabetical order! I need help 🤪 

I noticed however that other resource types are exported as singular nouns so I've corrected that with Payment.

I also noticed that we were missing `Payment` and `Upload` types in `index.ts` so I've added those. Hopefully it doesn't cause much harm to any work you all have in progress @selmanuysal @otaviojacobi 