### PR TITLE
feat: add shipment_exceptions endpoint and update schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 coverage/
 .DS_Store
 arta-node-*.tgz
+.tool-versions

--- a/lib/arta.ts
+++ b/lib/arta.ts
@@ -23,6 +23,7 @@ import { TrackingsEndpoint } from './endpoint/trackings';
 import { QuoteRequestsEndpoint } from './endpoint/requests';
 import { SelfShipCollectionAvailabilityChecksEndpoint } from './endpoint/selfShipCollectionAvailabilityChecks';
 import { SelfShipCollectionsEndpoint } from './endpoint/selfShipCollections';
+import { ShipmentExceptionsEndpoint } from './endpoint/shipmentExceptions';
 import { ShipmentsEndpoint } from './endpoint/shipments';
 import { TagsEndpoint } from './endpoint/tags';
 import { ImportCostEstimatesEndpoint } from './endpoint/importCostEstimates';
@@ -59,6 +60,7 @@ export class Arta {
   public requests: QuoteRequestsEndpoint;
   public self_ship_collection_availability_checks: SelfShipCollectionAvailabilityChecksEndpoint;
   public self_ship_collections: SelfShipCollectionsEndpoint;
+  public shipment_exceptions: ShipmentExceptionsEndpoint;
   public shipments: ShipmentsEndpoint;
   public tags: TagsEndpoint;
   public trackings: TrackingsEndpoint;
@@ -99,6 +101,7 @@ export class Arta {
     this.self_ship_collections = new SelfShipCollectionsEndpoint(
       this.artaClient,
     );
+    this.shipment_exceptions = new ShipmentExceptionsEndpoint(this.artaClient);
     this.shipments = new ShipmentsEndpoint(this.artaClient);
     this.tags = new TagsEndpoint(this.artaClient);
     this.trackings = new TrackingsEndpoint(this.artaClient);

--- a/lib/endpoint/shipmentExceptions.ts
+++ b/lib/endpoint/shipmentExceptions.ts
@@ -1,0 +1,69 @@
+import type { ArtaID } from '../ArtaClient';
+import type { RestClient } from '../net/RestClient';
+import type { Endpoint } from './endpoint';
+import { DefaultEndpoint } from './endpoint';
+import type { Page } from '../pagination';
+import type { ShipmentException } from '../types';
+
+export interface ShipmentExceptionCreateBody {
+  type: 'requested_hold_to_collect';
+  shipment_id: string;
+  hold_until?: string;
+}
+
+export interface ShipmentExceptionCreate {
+  shipment_exception: ShipmentExceptionCreateBody;
+}
+
+export type ShipmentExceptionUpdateBody = Partial<
+  Pick<ShipmentException, 'hold_until' | 'status'>
+>;
+
+export interface ShipmentExceptionUpdate {
+  shipment_exception: ShipmentExceptionUpdateBody;
+}
+
+export class ShipmentExceptionsEndpoint {
+  private readonly defaultEndpoint: Endpoint<
+    ShipmentException,
+    ShipmentExceptionCreate
+  >;
+  private readonly path = '/shipment_exceptions';
+  constructor(private readonly artaClient: RestClient) {
+    this.defaultEndpoint = new DefaultEndpoint<
+      ShipmentException,
+      ShipmentExceptionCreate
+    >(this.path, this.artaClient);
+  }
+
+  public getById(id: ArtaID, auth?: string): Promise<ShipmentException> {
+    return this.defaultEndpoint.getById(id, auth);
+  }
+
+  public list(
+    page = 1,
+    pageSize = 20,
+    auth?: string,
+  ): Promise<Page<ShipmentException>> {
+    return this.defaultEndpoint.list({ page, page_size: pageSize }, auth);
+  }
+
+  public create(
+    payload: ShipmentExceptionCreateBody,
+    auth?: string,
+  ): Promise<ShipmentException> {
+    return this.defaultEndpoint.create({ shipment_exception: payload }, auth);
+  }
+
+  public update(
+    id: ArtaID,
+    payload: ShipmentExceptionUpdateBody,
+    auth?: string,
+  ): Promise<ShipmentException> {
+    return this.defaultEndpoint.update(
+      id,
+      { shipment_exception: payload } as Partial<ShipmentExceptionCreate>,
+      auth,
+    );
+  }
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -27,4 +27,8 @@ export {
 } from './endpoint/requests';
 export { SelfShipCollectionAvailabilityCheckCreateBody } from './endpoint/selfShipCollectionAvailabilityChecks';
 export { SelfShipCollectionCreateBody } from './endpoint/selfShipCollections';
+export {
+  ShipmentExceptionCreateBody,
+  ShipmentExceptionUpdateBody,
+} from './endpoint/shipmentExceptions';
 export { ShipmentCreateBody } from './endpoint/shipments';

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -170,6 +170,7 @@ export type QuoteRequest = {
       | 'under_weight';
   }[];
   objects: {
+    id?: (number | null) | undefined;
     internal_reference?: (string | null) | undefined;
     current_packing?:
       | (
@@ -181,6 +182,10 @@ export type QuoteRequest = {
               | 'cardboard_box'
               | 'chandelier_box'
               | 'chair_box'
+              | 'dinnerware_box'
+              | 'fedex_small_box'
+              | 'fedex_medium_box'
+              | 'fedex_large_box'
               | 'cbin_closed'
               | 'cbin_open'
               | 'ply_box'
@@ -196,7 +201,9 @@ export type QuoteRequest = {
               | 'foam_lined_box'
               | 'cavity_box'
               | 'strongbox'
+              | 'strongbox_airseapacking'
               | 'double_box'
+              | 'double_box_airseapacking'
               | 'travel_frame'
               | 'travel_frame_art'
               | 'travel_frame_other'
@@ -208,6 +215,7 @@ export type QuoteRequest = {
               | 'pallet'
               | 'international_pallet'
               | 'portfolio'
+              | 'flat_mailer'
               | 'rug_rolled'
               | 'shadow_box'
               | 'slipcase'
@@ -227,6 +235,14 @@ export type QuoteRequest = {
             )[]
           | null
         )
+      | undefined;
+    customs?:
+      | ({
+          country_of_origin?: (string | null) | undefined;
+          hs_code?: (string | null) | undefined;
+          medium?: (string | null) | undefined;
+          temporary_admission?: (boolean | null) | undefined;
+        } | null)
       | undefined;
     details?:
       | ({
@@ -407,6 +423,7 @@ export type QuoteRequest = {
       | 'work_on_paper_framed_glass'
       | 'work_on_paper_framed_plexi'
       | 'work_on_paper_unframed';
+    type?: (string | null) | undefined;
     unit_of_measurement?: (string | null) | undefined;
     weight_unit?: (string | null) | undefined;
     value_currency: 'CAD' | 'CHF' | 'EUR' | 'GBP' | 'HKD' | 'USD';
@@ -755,9 +772,13 @@ export type Shipment = {
             updated_at: Date;
             created_at: Date;
             exception_type_label?: (string | null) | undefined;
+            hold_until?: (string | null) | undefined;
             id: string;
+            object_id?: (number | null) | undefined;
             package_id?: (number | null) | undefined;
             resolution?: (string | null) | undefined;
+            shipment_id?: (string | null) | undefined;
+            source: string;
             status: 'in_progress' | 'new' | 'resolved';
             type:
               | 'change_of_address_request'
@@ -776,6 +797,7 @@ export type Shipment = {
               | 'requested_hold_to_collect'
               | 'requested_hold_to_deliver'
               | 'wrong_item';
+            user_notes?: (string[] | null) | undefined;
           }[]
         | null
       )
@@ -842,6 +864,7 @@ export type Shipment = {
             id: number;
             is_sufficiently_packed: boolean;
             objects: {
+              id?: (number | null) | undefined;
               internal_reference?: (string | null) | undefined;
               current_packing?:
                 | (
@@ -853,6 +876,10 @@ export type Shipment = {
                         | 'cardboard_box'
                         | 'chandelier_box'
                         | 'chair_box'
+                        | 'dinnerware_box'
+                        | 'fedex_small_box'
+                        | 'fedex_medium_box'
+                        | 'fedex_large_box'
                         | 'cbin_closed'
                         | 'cbin_open'
                         | 'ply_box'
@@ -868,7 +895,9 @@ export type Shipment = {
                         | 'foam_lined_box'
                         | 'cavity_box'
                         | 'strongbox'
+                        | 'strongbox_airseapacking'
                         | 'double_box'
+                        | 'double_box_airseapacking'
                         | 'travel_frame'
                         | 'travel_frame_art'
                         | 'travel_frame_other'
@@ -880,6 +909,7 @@ export type Shipment = {
                         | 'pallet'
                         | 'international_pallet'
                         | 'portfolio'
+                        | 'flat_mailer'
                         | 'rug_rolled'
                         | 'shadow_box'
                         | 'slipcase'
@@ -899,6 +929,14 @@ export type Shipment = {
                       )[]
                     | null
                   )
+                | undefined;
+              customs?:
+                | ({
+                    country_of_origin?: (string | null) | undefined;
+                    hs_code?: (string | null) | undefined;
+                    medium?: (string | null) | undefined;
+                    temporary_admission?: (boolean | null) | undefined;
+                  } | null)
                 | undefined;
               details?:
                 | ({
@@ -1079,6 +1117,7 @@ export type Shipment = {
                 | 'work_on_paper_framed_glass'
                 | 'work_on_paper_framed_plexi'
                 | 'work_on_paper_unframed';
+              type?: (string | null) | undefined;
               unit_of_measurement?: (string | null) | undefined;
               weight_unit?: (string | null) | undefined;
               value_currency: 'CAD' | 'CHF' | 'EUR' | 'GBP' | 'HKD' | 'USD';
@@ -1245,6 +1284,10 @@ export type Shipment = {
               | 'cardboard_box'
               | 'chandelier_box'
               | 'chair_box'
+              | 'dinnerware_box'
+              | 'fedex_small_box'
+              | 'fedex_medium_box'
+              | 'fedex_large_box'
               | 'cbin_closed'
               | 'cbin_open'
               | 'ply_box'
@@ -1260,7 +1303,9 @@ export type Shipment = {
               | 'foam_lined_box'
               | 'cavity_box'
               | 'strongbox'
+              | 'strongbox_airseapacking'
               | 'double_box'
+              | 'double_box_airseapacking'
               | 'travel_frame'
               | 'travel_frame_art'
               | 'travel_frame_other'
@@ -1272,6 +1317,7 @@ export type Shipment = {
               | 'pallet'
               | 'international_pallet'
               | 'portfolio'
+              | 'flat_mailer'
               | 'rug_rolled'
               | 'shadow_box'
               | 'slipcase'
@@ -1536,6 +1582,7 @@ export type HostedSession = {
     | undefined;
   internal_reference?: (string | null) | undefined;
   objects: {
+    id?: (number | null) | undefined;
     internal_reference?: (string | null) | undefined;
     current_packing?:
       | (
@@ -1547,6 +1594,10 @@ export type HostedSession = {
               | 'cardboard_box'
               | 'chandelier_box'
               | 'chair_box'
+              | 'dinnerware_box'
+              | 'fedex_small_box'
+              | 'fedex_medium_box'
+              | 'fedex_large_box'
               | 'cbin_closed'
               | 'cbin_open'
               | 'ply_box'
@@ -1562,7 +1613,9 @@ export type HostedSession = {
               | 'foam_lined_box'
               | 'cavity_box'
               | 'strongbox'
+              | 'strongbox_airseapacking'
               | 'double_box'
+              | 'double_box_airseapacking'
               | 'travel_frame'
               | 'travel_frame_art'
               | 'travel_frame_other'
@@ -1574,6 +1627,7 @@ export type HostedSession = {
               | 'pallet'
               | 'international_pallet'
               | 'portfolio'
+              | 'flat_mailer'
               | 'rug_rolled'
               | 'shadow_box'
               | 'slipcase'
@@ -1593,6 +1647,14 @@ export type HostedSession = {
             )[]
           | null
         )
+      | undefined;
+    customs?:
+      | ({
+          country_of_origin?: (string | null) | undefined;
+          hs_code?: (string | null) | undefined;
+          medium?: (string | null) | undefined;
+          temporary_admission?: (boolean | null) | undefined;
+        } | null)
       | undefined;
     details?:
       | ({
@@ -1773,6 +1835,7 @@ export type HostedSession = {
       | 'work_on_paper_framed_glass'
       | 'work_on_paper_framed_plexi'
       | 'work_on_paper_unframed';
+    type?: (string | null) | undefined;
     unit_of_measurement?: (string | null) | undefined;
     weight_unit?: (string | null) | undefined;
     value_currency: 'CAD' | 'CHF' | 'EUR' | 'GBP' | 'HKD' | 'USD';
@@ -2384,6 +2447,7 @@ export type ArtaLocation = {
 };
 export type Insurance = 'arta_transit_insurance' | 'no_arta_insurance';
 export type ArtaObject = {
+  id?: (number | null) | undefined;
   internal_reference?: (string | null) | undefined;
   current_packing?:
     | (
@@ -2395,6 +2459,10 @@ export type ArtaObject = {
             | 'cardboard_box'
             | 'chandelier_box'
             | 'chair_box'
+            | 'dinnerware_box'
+            | 'fedex_small_box'
+            | 'fedex_medium_box'
+            | 'fedex_large_box'
             | 'cbin_closed'
             | 'cbin_open'
             | 'ply_box'
@@ -2410,7 +2478,9 @@ export type ArtaObject = {
             | 'foam_lined_box'
             | 'cavity_box'
             | 'strongbox'
+            | 'strongbox_airseapacking'
             | 'double_box'
+            | 'double_box_airseapacking'
             | 'travel_frame'
             | 'travel_frame_art'
             | 'travel_frame_other'
@@ -2422,6 +2492,7 @@ export type ArtaObject = {
             | 'pallet'
             | 'international_pallet'
             | 'portfolio'
+            | 'flat_mailer'
             | 'rug_rolled'
             | 'shadow_box'
             | 'slipcase'
@@ -2441,6 +2512,14 @@ export type ArtaObject = {
           )[]
         | null
       )
+    | undefined;
+  customs?:
+    | ({
+        country_of_origin?: (string | null) | undefined;
+        hs_code?: (string | null) | undefined;
+        medium?: (string | null) | undefined;
+        temporary_admission?: (boolean | null) | undefined;
+      } | null)
     | undefined;
   details?:
     | ({
@@ -2621,6 +2700,7 @@ export type ArtaObject = {
     | 'work_on_paper_framed_glass'
     | 'work_on_paper_framed_plexi'
     | 'work_on_paper_unframed';
+  type?: (string | null) | undefined;
   unit_of_measurement?: (string | null) | undefined;
   weight_unit?: (string | null) | undefined;
   value_currency: 'CAD' | 'CHF' | 'EUR' | 'GBP' | 'HKD' | 'USD';
@@ -2799,6 +2879,7 @@ export type Package = {
   id: number;
   is_sufficiently_packed: boolean;
   objects: {
+    id?: (number | null) | undefined;
     internal_reference?: (string | null) | undefined;
     current_packing?:
       | (
@@ -2810,6 +2891,10 @@ export type Package = {
               | 'cardboard_box'
               | 'chandelier_box'
               | 'chair_box'
+              | 'dinnerware_box'
+              | 'fedex_small_box'
+              | 'fedex_medium_box'
+              | 'fedex_large_box'
               | 'cbin_closed'
               | 'cbin_open'
               | 'ply_box'
@@ -2825,7 +2910,9 @@ export type Package = {
               | 'foam_lined_box'
               | 'cavity_box'
               | 'strongbox'
+              | 'strongbox_airseapacking'
               | 'double_box'
+              | 'double_box_airseapacking'
               | 'travel_frame'
               | 'travel_frame_art'
               | 'travel_frame_other'
@@ -2837,6 +2924,7 @@ export type Package = {
               | 'pallet'
               | 'international_pallet'
               | 'portfolio'
+              | 'flat_mailer'
               | 'rug_rolled'
               | 'shadow_box'
               | 'slipcase'
@@ -2856,6 +2944,14 @@ export type Package = {
             )[]
           | null
         )
+      | undefined;
+    customs?:
+      | ({
+          country_of_origin?: (string | null) | undefined;
+          hs_code?: (string | null) | undefined;
+          medium?: (string | null) | undefined;
+          temporary_admission?: (boolean | null) | undefined;
+        } | null)
       | undefined;
     details?:
       | ({
@@ -3036,6 +3132,7 @@ export type Package = {
       | 'work_on_paper_framed_glass'
       | 'work_on_paper_framed_plexi'
       | 'work_on_paper_unframed';
+    type?: (string | null) | undefined;
     unit_of_measurement?: (string | null) | undefined;
     weight_unit?: (string | null) | undefined;
     value_currency: 'CAD' | 'CHF' | 'EUR' | 'GBP' | 'HKD' | 'USD';
@@ -3197,6 +3294,10 @@ export type Package = {
     | 'cardboard_box'
     | 'chandelier_box'
     | 'chair_box'
+    | 'dinnerware_box'
+    | 'fedex_small_box'
+    | 'fedex_medium_box'
+    | 'fedex_large_box'
     | 'cbin_closed'
     | 'cbin_open'
     | 'ply_box'
@@ -3212,7 +3313,9 @@ export type Package = {
     | 'foam_lined_box'
     | 'cavity_box'
     | 'strongbox'
+    | 'strongbox_airseapacking'
     | 'double_box'
+    | 'double_box_airseapacking'
     | 'travel_frame'
     | 'travel_frame_art'
     | 'travel_frame_other'
@@ -3224,6 +3327,7 @@ export type Package = {
     | 'pallet'
     | 'international_pallet'
     | 'portfolio'
+    | 'flat_mailer'
     | 'rug_rolled'
     | 'shadow_box'
     | 'slipcase'
@@ -3283,9 +3387,13 @@ export type ShipmentException = {
   updated_at: Date;
   created_at: Date;
   exception_type_label?: (string | null) | undefined;
+  hold_until?: (string | null) | undefined;
   id: string;
+  object_id?: (number | null) | undefined;
   package_id?: (number | null) | undefined;
   resolution?: (string | null) | undefined;
+  shipment_id?: (string | null) | undefined;
+  source: string;
   status: 'in_progress' | 'new' | 'resolved';
   type:
     | 'change_of_address_request'
@@ -3304,6 +3412,7 @@ export type ShipmentException = {
     | 'requested_hold_to_collect'
     | 'requested_hold_to_deliver'
     | 'wrong_item';
+  user_notes?: (string[] | null) | undefined;
 };
 export type ShipmentSchedule = {
   delivery_end?: (Date | null) | undefined;
@@ -3950,6 +4059,7 @@ export type InboundHostedSession = {
     | undefined;
   internal_reference?: (string | null) | undefined;
   objects: {
+    id?: (number | null) | undefined;
     internal_reference?: (string | null) | undefined;
     current_packing?:
       | (
@@ -3961,6 +4071,10 @@ export type InboundHostedSession = {
               | 'cardboard_box'
               | 'chandelier_box'
               | 'chair_box'
+              | 'dinnerware_box'
+              | 'fedex_small_box'
+              | 'fedex_medium_box'
+              | 'fedex_large_box'
               | 'cbin_closed'
               | 'cbin_open'
               | 'ply_box'
@@ -3976,7 +4090,9 @@ export type InboundHostedSession = {
               | 'foam_lined_box'
               | 'cavity_box'
               | 'strongbox'
+              | 'strongbox_airseapacking'
               | 'double_box'
+              | 'double_box_airseapacking'
               | 'travel_frame'
               | 'travel_frame_art'
               | 'travel_frame_other'
@@ -3988,6 +4104,7 @@ export type InboundHostedSession = {
               | 'pallet'
               | 'international_pallet'
               | 'portfolio'
+              | 'flat_mailer'
               | 'rug_rolled'
               | 'shadow_box'
               | 'slipcase'
@@ -4007,6 +4124,14 @@ export type InboundHostedSession = {
             )[]
           | null
         )
+      | undefined;
+    customs?:
+      | ({
+          country_of_origin?: (string | null) | undefined;
+          hs_code?: (string | null) | undefined;
+          medium?: (string | null) | undefined;
+          temporary_admission?: (boolean | null) | undefined;
+        } | null)
       | undefined;
     details?:
       | ({
@@ -4187,6 +4312,7 @@ export type InboundHostedSession = {
       | 'work_on_paper_framed_glass'
       | 'work_on_paper_framed_plexi'
       | 'work_on_paper_unframed';
+    type?: (string | null) | undefined;
     unit_of_measurement?: (string | null) | undefined;
     weight_unit?: (string | null) | undefined;
     value_currency: 'CAD' | 'CHF' | 'EUR' | 'GBP' | 'HKD' | 'USD';
@@ -4424,6 +4550,7 @@ export type InboundHostedSession = {
   quoting_strategy: 'all_rates' | 'best_rate' | 'compare_carriers';
 };
 export type ArtaInboundObject = {
+  id?: (number | null) | undefined;
   internal_reference?: (string | null) | undefined;
   current_packing?:
     | (
@@ -4435,6 +4562,10 @@ export type ArtaInboundObject = {
             | 'cardboard_box'
             | 'chandelier_box'
             | 'chair_box'
+            | 'dinnerware_box'
+            | 'fedex_small_box'
+            | 'fedex_medium_box'
+            | 'fedex_large_box'
             | 'cbin_closed'
             | 'cbin_open'
             | 'ply_box'
@@ -4450,7 +4581,9 @@ export type ArtaInboundObject = {
             | 'foam_lined_box'
             | 'cavity_box'
             | 'strongbox'
+            | 'strongbox_airseapacking'
             | 'double_box'
+            | 'double_box_airseapacking'
             | 'travel_frame'
             | 'travel_frame_art'
             | 'travel_frame_other'
@@ -4462,6 +4595,7 @@ export type ArtaInboundObject = {
             | 'pallet'
             | 'international_pallet'
             | 'portfolio'
+            | 'flat_mailer'
             | 'rug_rolled'
             | 'shadow_box'
             | 'slipcase'
@@ -4481,6 +4615,14 @@ export type ArtaInboundObject = {
           )[]
         | null
       )
+    | undefined;
+  customs?:
+    | ({
+        country_of_origin?: (string | null) | undefined;
+        hs_code?: (string | null) | undefined;
+        medium?: (string | null) | undefined;
+        temporary_admission?: (boolean | null) | undefined;
+      } | null)
     | undefined;
   details?:
     | ({
@@ -4661,6 +4803,7 @@ export type ArtaInboundObject = {
     | 'work_on_paper_framed_glass'
     | 'work_on_paper_framed_plexi'
     | 'work_on_paper_unframed';
+  type?: (string | null) | undefined;
   unit_of_measurement?: (string | null) | undefined;
   weight_unit?: (string | null) | undefined;
   value_currency: 'CAD' | 'CHF' | 'EUR' | 'GBP' | 'HKD' | 'USD';

--- a/schemas/index.ts
+++ b/schemas/index.ts
@@ -73,6 +73,10 @@ const packingSubTypeSchema = z.enum([
   'cardboard_box',
   'chandelier_box',
   'chair_box',
+  'dinnerware_box',
+  'fedex_small_box',
+  'fedex_medium_box',
+  'fedex_large_box',
   'cbin_closed',
   'cbin_open',
   'ply_box',
@@ -88,7 +92,9 @@ const packingSubTypeSchema = z.enum([
   'foam_lined_box',
   'cavity_box',
   'strongbox',
+  'strongbox_airseapacking',
   'double_box',
+  'double_box_airseapacking',
   'travel_frame',
   'travel_frame_art',
   'travel_frame_other',
@@ -100,6 +106,7 @@ const packingSubTypeSchema = z.enum([
   'pallet',
   'international_pallet',
   'portfolio',
+  'flat_mailer',
   'rug_rolled',
   'shadow_box',
   'slipcase',
@@ -501,8 +508,17 @@ export const componentSchema = z.object({
 });
 
 export const artaObjectSchema = z.object({
+  id: numId.nullish(),
   internal_reference: z.string().nullish(),
   current_packing: z.array(packingSubTypeSchema).nullish(),
+  customs: z
+    .object({
+      country_of_origin: z.string().nullish(),
+      hs_code: z.string().nullish(),
+      medium: z.string().nullish(),
+      temporary_admission: z.boolean().nullish(),
+    })
+    .nullish(),
   details: detailsSchema.nullish(),
   height: zodNumberOrString,
   width: zodNumberOrString,
@@ -512,6 +528,7 @@ export const artaObjectSchema = z.object({
   images: z.array(z.string()).nullish(),
   public_reference: z.string().nullish(),
   subtype: objectSubTypeSchema,
+  type: z.string().nullish(),
   unit_of_measurement: z.string().nullish(),
   weight_unit: z.string().nullish(),
   value_currency: supportedCurrencySchema,
@@ -729,11 +746,16 @@ export const shipmentExceptionTypeIdSchema = z.enum([
 
 export const shipmentExceptionSchema = datedSchema.extend({
   exception_type_label: z.string().nullish(),
+  hold_until: z.string().nullish(),
   id: z.string().uuid(),
+  object_id: z.number().nullish(),
   package_id: z.number().nullish(),
   resolution: z.string().nullish(),
+  shipment_id: z.string().uuid().nullish(),
+  source: z.string(),
   status: shipmentExceptionStatusSchema,
   type: shipmentExceptionTypeIdSchema,
+  user_notes: z.array(z.string()).nullish(),
 });
 
 export const shipmentScheduleSchema = z.object({

--- a/test/endpoint/shipmentExceptions.test.ts
+++ b/test/endpoint/shipmentExceptions.test.ts
@@ -1,0 +1,51 @@
+import type { RestClient } from '../../lib/net/RestClient';
+import {
+  type ShipmentExceptionCreateBody,
+  ShipmentExceptionsEndpoint,
+} from '../../lib/endpoint/shipmentExceptions';
+import * as helper from './helper';
+
+describe('tests shipment exceptions Arta endpoint', () => {
+  const responseMock = {
+    id: 'd686ad3b-33fd-454c-a7aa-94b1ecbc539f',
+    created_at: '2023-05-26T19:33:19.693833',
+    updated_at: '2023-05-26T19:33:19.693833',
+    exception_type_label: null,
+    hold_until: null,
+    object_id: null,
+    package_id: null,
+    resolution: null,
+    shipment_id: 'a5cbb58c-43ab-4658-9999-98a33b0070d5',
+    source: 'api',
+    status: 'new',
+    type: 'requested_hold_to_collect',
+    user_notes: [],
+  };
+  const path = 'shipment_exceptions';
+  let clientMock: RestClient;
+  let endpoint: ShipmentExceptionsEndpoint;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    clientMock = helper.getRestMock(responseMock);
+    endpoint = new ShipmentExceptionsEndpoint(clientMock);
+  });
+
+  it('should have get, create, update and list methods', async () => {
+    const requestConfig = { path, clientMock, endpoint };
+    const createPayload = {
+      type: 'requested_hold_to_collect',
+      shipment_id: 'a5cbb58c-43ab-4658-9999-98a33b0070d5',
+      hold_until: '2023-08-15',
+    } satisfies ShipmentExceptionCreateBody;
+
+    await helper.testGet(requestConfig);
+    await helper.testCreate(createPayload, 'shipment_exception', requestConfig);
+    await helper.testList(responseMock, requestConfig);
+    await helper.testUpdate(
+      { status: 'resolved' },
+      'shipment_exception',
+      requestConfig,
+    );
+  });
+});

--- a/test/endpoint/shipments.mock.ts
+++ b/test/endpoint/shipments.mock.ts
@@ -33,9 +33,12 @@ export const responseMock = {
     {
       created_at: '2021-01-23T20:37:51.930357',
       exception_type_label: null,
+      hold_until: null,
       id: '196b2aba-24a1-4a06-9a15-6bd822d97704',
+      object_id: null,
       package_id: null,
       resolution: 'EEI Form Submitted',
+      source: 'automatic',
       status: 'resolved',
       type: 'customs_information_required',
       updated_at: '2021-01-23T20:37:51.930357',


### PR DESCRIPTION
Add a new ShipmentExceptionsEndpoint with list, get, create, and update operations for the /shipment_exceptions API resource.

Update schemas to match actual API responses:
- shipmentExceptionSchema: add hold_until, object_id, shipment_id, source, and user_notes fields
- artaObjectSchema: add id, type, and customs fields
- packingSubTypeSchema: add 7 missing packing material keys